### PR TITLE
Add HunYuan MoE model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ eval "$CMD"
 - Only supports NVIDIA
 - Only supports llama.cpp
 - Only supports GGUF files from Hugging Face
-- Only supports Qwen, Llama, Mistral, and DeepSeek architectures
+- Only supports Qwen, Llama, Mistral, DeepSeek, and HunYuan MoE architectures
 
 ## Can I use this code for xyz?
 

--- a/__test__/hunyuan-moe/dump.json
+++ b/__test__/hunyuan-moe/dump.json
@@ -1,0 +1,45 @@
+{
+  "metadata": {
+    "version": 3,
+    "tensor_count": 4,
+    "kv_count": 1,
+    "general.architecture": "hunyuan-moe",
+    "hunyuan-moe.block_count": 2,
+    "hunyuan-moe.context_length": 2048,
+    "hunyuan-moe.embedding_length": 4096,
+    "hunyuan-moe.feed_forward_length": 3072,
+    "hunyuan-moe.attention.head_count": 32,
+    "hunyuan-moe.attention.head_count_kv": 8
+  },
+  "tensorInfos": [
+    {
+      "name": "token_embd.weight",
+      "n_dims": 2,
+      "shape": [4096, 128],
+      "dtype": 14,
+      "offset": 0
+    },
+    {
+      "name": "blk.0.attn_q.weight",
+      "n_dims": 2,
+      "shape": [4096, 4096],
+      "dtype": 14,
+      "offset": 1000
+    },
+    {
+      "name": "blk.0.ffn_gate_exps.weight",
+      "n_dims": 3,
+      "shape": [4096, 3072, 1],
+      "dtype": 14,
+      "offset": 2000
+    },
+    {
+      "name": "output.weight",
+      "n_dims": 2,
+      "shape": [128, 4096],
+      "dtype": 14,
+      "offset": 3000
+    }
+  ],
+  "tensorDataOffset": 0
+}

--- a/__test__/hunyuan-moe/test.ts
+++ b/__test__/hunyuan-moe/test.ts
@@ -1,0 +1,48 @@
+import Log from "../../src/log.ts";
+import optimize from "../../src/optimize.ts";
+import {
+  assertEqual,
+  baselineContextLength,
+  baselineContextQuantizationSize,
+  baselineGpus,
+  baselineRamBytes,
+} from "../test-utils.ts";
+import dump from "./dump.json" with { type: "json" };
+
+export function testHunyuanAllocates() {
+  Log.noLog = true;
+  const result = optimize({
+    gguf: dump as any,
+    gpus: baselineGpus(),
+    ramBytes: baselineRamBytes(),
+    check: true,
+    gpuPercentage: 1,
+    contextLength: baselineContextLength(),
+    contextQuantizationSize: baselineContextQuantizationSize(),
+  });
+  let totalBytesAllocated = 0;
+  for (const device of result.deviceAllocation) {
+    totalBytesAllocated += device.bytesAllocated;
+  }
+  assertEqual(totalBytesAllocated > 0, true, "No bytes were allocated");
+}
+
+export function testHunyuanNoGpuOverrun() {
+  Log.noLog = true;
+  const result = optimize({
+    gguf: dump as any,
+    gpus: baselineGpus(),
+    ramBytes: baselineRamBytes(),
+    check: true,
+    gpuPercentage: 1,
+    contextLength: baselineContextLength(),
+    contextQuantizationSize: baselineContextQuantizationSize(),
+  });
+  for (const device of result.deviceAllocation) {
+    assertEqual(
+      device.bytesAllocated < device.memoryTotalBytes,
+      true,
+      `Device ${device.name} has overrun: ${device.bytesAllocated} >= ${device.memoryTotalBytes}`
+    );
+  }
+}

--- a/__test__/index.ts
+++ b/__test__/index.ts
@@ -2,6 +2,12 @@ import {
   testEverythingAllocated,
   testNoGpuOverrun,
 } from "./qwen3-235-q4ks/test.ts";
+import {
+  testHunyuanAllocates,
+  testHunyuanNoGpuOverrun,
+} from "./hunyuan-moe/test.ts";
 
 testEverythingAllocated();
 testNoGpuOverrun();
+testHunyuanAllocates();
+testHunyuanNoGpuOverrun();

--- a/src/optimize.ts
+++ b/src/optimize.ts
@@ -69,6 +69,16 @@ function extractMetadata(gguf: GGUFParseOutput): {
           gguf.metadata["qwen3moe.embedding_length"] /
           gguf.metadata["qwen3moe.attention.head_count"],
       };
+    case "hunyuan-moe" as string:
+      return {
+        hiddenSize: gguf.metadata["hunyuan-moe.embedding_length"],
+        numAttentionHeads: gguf.metadata["hunyuan-moe.attention.head_count"],
+        numLayers: gguf.metadata["hunyuan-moe.block_count"],
+        numKeyValueHeads: gguf.metadata["hunyuan-moe.attention.head_count_kv"],
+        headSize:
+          gguf.metadata["hunyuan-moe.embedding_length"] /
+          gguf.metadata["hunyuan-moe.attention.head_count"],
+      };
     case "qwen3" as string:
       return {
         hiddenSize: gguf.metadata["qwen3.embedding_length"],


### PR DESCRIPTION
## Summary
- support `hunyuan-moe` architecture in optimizer
- document HunYuan MoE support
- add HunYuan MoE test data and tests
- execute new tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686dc4053780832fbc4934340513913d